### PR TITLE
fix: Enhance client-side AI response handling and logging

### DIFF
--- a/src/services/api/messageService.ts
+++ b/src/services/api/messageService.ts
@@ -76,6 +76,19 @@ export const sendMessage = async (
       contextMessages,
       attachments
     );
+
+    // Log and validate the AI response object
+    console.log('AI response object before saving in messageService:', aiResponseContent);
+
+    if (!aiResponseContent || typeof aiResponseContent.generatedText !== 'string') {
+      console.error('Invalid AI response: generatedText is missing or not a string. Full object:', aiResponseContent);
+      throw new Error("Invalid AI response content (text missing/wrong type)");
+    }
+
+    if (!Array.isArray(aiResponseContent.sourceUrls)) {
+      console.warn('Invalid AI response: sourceUrls is not an array. Defaulting to empty. Full object:', aiResponseContent);
+      aiResponseContent.sourceUrls = [];
+    }
     
     // Insert AI response
     const { data: aiMessageData, error: aiMessageError } = await supabase


### PR DESCRIPTION
- I've modified `aiResponseHandlers.ts` to ensure `getAiResponse` consistently returns an object of the shape `{ generatedText: string, sourceUrls: string[] }`.
- I've added detailed logging for the object received from `aiProviderService`.
- I've handled cases where `aiProviderService` might return a string (e.g., fallback messages) and packaged it correctly.
- I've modified `messageService.ts` to log the AI response object before saving and added more rigorous checks for `generatedText` (must be string) and `sourceUrls` (must be an array, defaults to empty if not).
- I've made it so an error is thrown if `generatedText` is invalid to prevent saving bad data, leading to clearer client-side error reporting.