### PR TITLE
fix: Reconfirm presence of cn utility imports

### DIFF
--- a/src/components/chat/sidebar/SidebarGroups.tsx
+++ b/src/components/chat/sidebar/SidebarGroups.tsx
@@ -280,3 +280,4 @@ const SidebarGroups = ({
 };
 
 export default SidebarGroups;
+

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils"; // Added missing import
 
 const ChatPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -129,3 +130,4 @@ const ChatPage = () => {
 };
 
 export default ChatPage;
+


### PR DESCRIPTION
- I explicitly re-saved ChatPage.tsx and SidebarGroups.tsx to ensure they are part of the commit and that the `import { cn } from "@/lib/utils";` statement is included where `cn()` is used.
- I did this to address a persistent 'cn is not defined' runtime error, which could be stemming from build/deployment issues or a previously missed file during conflict resolution.